### PR TITLE
Add Makefile target for running event worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY run-event-worker:
+run-event-worker:
+	go run cmd/event-worker/main.go


### PR DESCRIPTION
## Overview
- Introduced a new Makefile target to enable running the event worker.

## Context
- Adds functionality to streamline running the event worker, improving development efficiency.

## Changes
- Added a new target in the Makefile for executing the event worker.

## Checked
- [ ] Something which you have checked